### PR TITLE
Including article title in share subject

### DIFF
--- a/src/com/commonsware/android/arXiv/SingleItemWindow.java
+++ b/src/com/commonsware/android/arXiv/SingleItemWindow.java
@@ -136,7 +136,7 @@ public class SingleItemWindow extends Activity implements View.OnClickListener {
         case SHARE_ID:
             Intent i = new Intent(android.content.Intent.ACTION_SEND);
             i.setType("text/plain");
-            i.putExtra(Intent.EXTRA_SUBJECT, "arXiv Article");
+            i.putExtra(Intent.EXTRA_SUBJECT, title + " (arXiv article)");
             i.putExtra(Intent.EXTRA_TEXT, title + " " + link);
             startActivity(Intent.createChooser(i, getString(R.string.share)));
             return (true);


### PR DESCRIPTION
People often share many articles to the same destination (evernote, trello, collegues via email). Having a more informative subject line is useful.