### PR TITLE
Add intent filter for browsing arXiv article URLs. 

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,6 +60,13 @@
                   android:hardwareAccelerated="true"
                   android:label="@string/app_name">
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:host="arxiv.org" android:scheme="https"/>
+                <data android:host="arxiv.org" android:scheme="http"/>
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>

--- a/src/com/commonsware/android/arXiv/SingleItemWindow.java
+++ b/src/com/commonsware/android/arXiv/SingleItemWindow.java
@@ -352,6 +352,15 @@ public class SingleItemWindow extends Activity implements View.OnClickListener {
                             //c.setDoOutput(true);
                             c.connect();
 
+                            if (c.getResponseCode() == 301) {
+                                // TODO proper handling of HTTP responses and errors
+                                u = new URL(c.getHeaderField("Location"));
+                                c.disconnect();
+                                c = (HttpURLConnection) u.openConnection();
+                                c.setRequestMethod("GET");
+                                assert c.getResponseCode() == 200;
+                            }
+
                             final long ifs = c.getContentLength();
                             InputStream in = c.getInputStream();
 

--- a/src/com/commonsware/android/arXiv/SingleItemWindow.java
+++ b/src/com/commonsware/android/arXiv/SingleItemWindow.java
@@ -216,7 +216,7 @@ public class SingleItemWindow extends Activity implements View.OnClickListener {
         creator = myIntent.getStringExtra("keycreator");
         description = myIntent.getStringExtra("keydescription");
         link = myIntent.getStringExtra("keylink");
-
+        link = link.replace("http://", "https://");
         progBar = (ProgressBar) findViewById(R.id.pbar); // Progressbar for
                                                          // download
 

--- a/src/com/commonsware/android/arXiv/SingleItemWindow.java
+++ b/src/com/commonsware/android/arXiv/SingleItemWindow.java
@@ -378,7 +378,7 @@ public class SingleItemWindow extends Activity implements View.OnClickListener {
                             File futureFile = new File(filepath, filename);
                             if (futureFile.exists()) {
                                 final long itmp = futureFile.length();
-                                if (itmp == ifs && itmp != 0) {
+                                if (itmp == ifs && itmp >301) {
                                     vdownload = false;
                                 }
                             }

--- a/src/com/commonsware/android/arXiv/arXiv.java
+++ b/src/com/commonsware/android/arXiv/arXiv.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -71,13 +73,13 @@ import android.app.PendingIntent;
 import android.widget.RemoteViews;
 
 import android.os.SystemClock;
-import android.net.Uri;
 
 import android.preference.PreferenceManager;
 import android.content.SharedPreferences;
 
 public class arXiv extends Activity implements AdapterView.OnItemClickListener {
 
+    public static final String ARXIV_PATTERN = "^https?://arxiv.org/(abs|pdf)/(.*)(v[0-9]+)?$";
     public Context thisActivity;
 
     //UI-Views
@@ -633,11 +635,14 @@ public class arXiv extends Activity implements AdapterView.OnItemClickListener {
 
         try {
             Intent myInIntent = getIntent();
-            String mytype = myInIntent.getStringExtra("keywidget");
-
-            if (mytype != null) {
-                vFromWidget = true;
-                tabs.setCurrentTabByTag("tag2");
+            if (myInIntent.getAction() == "android.intent.action.VIEW") {
+                searchFromUrlId(myInIntent.getData());
+            } else {
+                String mytype = myInIntent.getStringExtra("keywidget");
+                if (mytype != null) {
+                    vFromWidget = true;
+                    tabs.setCurrentTabByTag("tag2");
+                }
             }
         } catch (Exception ef) {
             Log.e("arxiv","Failed to change tab "+ef);
@@ -646,6 +651,32 @@ public class arXiv extends Activity implements AdapterView.OnItemClickListener {
         SharedPreferences prefs=PreferenceManager.getDefaultSharedPreferences(this);
         mySourcePref=Integer.parseInt(prefs.getString("sourcelist", "0"));
 
+    }
+
+    private String extractArXivId(Uri data) {
+        Pattern pattern = Pattern.compile(ARXIV_PATTERN);
+        Matcher matcher = pattern.matcher(data.toString());
+        if (matcher.find()) {
+            return matcher.group(2);
+        } else {
+            return "";
+        }
+    }
+
+    private void searchFromUrlId(Uri data) {
+        Log.i("arXiv", data.toString());
+        String arXivId = extractArXivId(data);
+
+        if (arXivId.length() > 0) {
+            Log.i("arXiv", arXivId);
+            Intent myIntent = new Intent(this, SearchListWindow.class);
+            myIntent.putExtra("keyquery", "id_list=" + arXivId);
+            myIntent.putExtra("keyname", arXivId);
+            myIntent.putExtra("keyurl", "");
+            startActivity(myIntent);
+        } else {
+            Log.e("arXiv", "No arXivId found in intent URL");
+        }
     }
 
     public void onCreateContextMenu(ContextMenu menu, View view,

--- a/src/com/commonsware/android/arXiv/arXiv.java
+++ b/src/com/commonsware/android/arXiv/arXiv.java
@@ -79,7 +79,7 @@ import android.content.SharedPreferences;
 
 public class arXiv extends Activity implements AdapterView.OnItemClickListener {
 
-    public static final String ARXIV_PATTERN = "^https?://arxiv.org/(abs|pdf)/(.*)(v[0-9]+)?$";
+    public static final String ARXIV_PATTERN = "^https?://arxiv.org/(abs|pdf)/([0-9]+\\.?[0-9]+).*";
     public Context thisActivity;
 
     //UI-Views


### PR DESCRIPTION
I use this app all the time, and it provides a nice repository of things I've read.

Adding support for browse intents kills two birds with one stone:
- it lets me see the abstract of a link someone shares before I download the PDF, even if they shared the PDF directly
- it means that all arXiv articles go through the app and so get logged in the history.
