### PR TITLE
add https redirect handling

### DIFF
--- a/src/com/commonsware/android/arXiv/NetworkUtils.java
+++ b/src/com/commonsware/android/arXiv/NetworkUtils.java
@@ -1,0 +1,43 @@
+package com.commonsware.android.arXiv;
+
+import android.util.Log;
+import android.widget.ProgressBar;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+
+public class NetworkUtils {
+    static String getRedirectUrl(String url) throws IOException {
+        URL u = new URL(url);
+        HttpURLConnection conn = (HttpURLConnection) u.openConnection();
+        conn.setRequestMethod("GET");
+        conn.connect();
+
+        boolean redirect = false;
+        int status = conn.getResponseCode();
+        if (status != HttpURLConnection.HTTP_OK) {
+            if (status == HttpURLConnection.HTTP_MOVED_TEMP
+                    || status == HttpURLConnection.HTTP_MOVED_PERM
+                    || status == HttpURLConnection.HTTP_SEE_OTHER)
+                redirect = true;
+        }
+        String newUrl;
+        if (redirect) {
+            // get redirect url from "location" header field
+            newUrl = conn.getHeaderField("Location");
+        }
+        else{
+            // no need to redirect
+            newUrl = url;
+        }
+
+        return newUrl;
+    }
+
+}

--- a/src/com/commonsware/android/arXiv/SingleItemWindow.java
+++ b/src/com/commonsware/android/arXiv/SingleItemWindow.java
@@ -344,6 +344,7 @@ public class SingleItemWindow extends Activity implements View.OnClickListener {
                             });
 
                             String pdfaddress = link.replace("abs", "pdf");
+                            pdfaddress = NetworkUtils.getRedirectUrl(pdfaddress);
 
                             URL u = new URL(pdfaddress);
                             HttpURLConnection c = (HttpURLConnection) u
@@ -506,6 +507,7 @@ public class SingleItemWindow extends Activity implements View.OnClickListener {
                 try {
                     String pdfaddress = link.replace("abs", "pdf");
 
+                    pdfaddress = NetworkUtils.getRedirectUrl(pdfaddress);
                     URL u = new URL(pdfaddress);
                     HttpURLConnection c = (HttpURLConnection) u
                             .openConnection();


### PR DESCRIPTION
Currently pdf downloading doesn't work because arxiv redirects http to https.
https://github.com/jdeslip/arxiv-mobile/issues/11
This pull request fixes this problem. 
