### PR TITLE
Add data loss patch for Search Activity

### DIFF
--- a/src/com/commonsware/android/arXiv/SearchWindow.java
+++ b/src/com/commonsware/android/arXiv/SearchWindow.java
@@ -149,6 +149,38 @@ public class SearchWindow extends Activity implements
             finalDate = "" + mYear + "0" + (mMonth + 1) + mDay + "2399";
         }
     }
+    
+    private static Bundle dataLossSave;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if (dataLossSave != null ) {
+            dataLossSave.clear();
+            dataLossSave = null ;
+        }
+        dataLossSave = new Bundle();
+        if(isSubmit){
+            dataLossSave.clear();
+            dataLossSave = null ;
+        }else {
+            dataLossSave.putString("editField1", field1.getText().toString());
+            dataLossSave.putString("editField2", field2.getText().toString());
+            dataLossSave.putString("editField3", field3.getText().toString());
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (dataLossSave != null ) {
+            field1.setText(dataLossSave.getString("editField1", ""));
+            field2.setText(dataLossSave.getString("editField2", ""));
+            field3.setText(dataLossSave.getString("editField3", ""));
+        }
+    }
 
     @Override
     protected Dialog onCreateDialog(int id) {
@@ -197,6 +229,7 @@ public class SearchWindow extends Activity implements
     }
 
     public void pressedSearchButton(View button) {
+        isSubmit = true;
         String query = "";
         String idlist = "";
         String tittext = "Search: " + textEntryValue1;


### PR DESCRIPTION
Hello developers of arxiv mobile

I am using your app privacy friendly notes. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate what activity that are changed in my patch:

https://ibb.co/mN1YmTG

When the user tries to do a new search. If the screen focus goes to another app or activity or if the user accidentally closes or press back the app, the user might lose any data they had put into this page

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I closed the activity and restarted it https://ibb.co/qdtCnVZ). Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim